### PR TITLE
Block cascade of --x-columns:auto. Fixes #2

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,5 @@ export function throttle(callback : Function, limit : number) {
     }
   }
 }
+
+export const css = String.raw;


### PR DESCRIPTION
Allow whitespace in value of --x-columns property if CSS Properties and Values is unsupported.